### PR TITLE
Make autoupdate configurable

### DIFF
--- a/gke.tf
+++ b/gke.tf
@@ -34,4 +34,8 @@ resource "google_container_cluster" "this" {
 
   logging_service     = "none"
   deletion_protection = false
+
+  release_channel {
+    channel = var.autoupdate ? "STABLE" : "UNSPECIFIED"
+  }
 }

--- a/manager_node_pool.tf
+++ b/manager_node_pool.tf
@@ -42,6 +42,6 @@ resource "google_container_node_pool" "manager" {
   }
 
   management {
-    auto_upgrade = false
+    auto_upgrade = var.autoupdate
   }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -18,6 +18,11 @@ variable "grant_registry_access" {
   default = false
 }
 
+variable "autoupdate" {
+  type = bool
+  default = false
+}
+
 variable "manager_node_pool_config" {
   type = object({
     name         = optional(string, "manager")

--- a/worker_node_pool.tf
+++ b/worker_node_pool.tf
@@ -52,7 +52,7 @@ resource "google_container_node_pool" "workers" {
   }
 
   management {
-    auto_upgrade = false
+    auto_upgrade = var.autoupdate
   }
 
   lifecycle {


### PR DESCRIPTION
# 변경 내용
* `autoupdate` variable을 추가합니다.
* `google_container_cluster.this` 리소스의 `release_channel` block을 추가합니다.
* `google_container_node_pool.manager` 리소스의 `management[0].auto_upgrade` 값을 수정합니다.
* `google_container_node_pool.workers` 리소스의 `management[0].auto_upgrade` 값을 수정합니다.

# 설명

Cluster가 rapid/regular/stable channel에 subscribe하고 있지 않은 경우에만 `auto_upgrade`를 끌 수 있습니다. 그래서 그걸 끌 수 있게 설정합니다.

끈 경우, control plane은 이를 무시하고 자동으로 업그레이드되기 때문에, 가만 두면 노드와 버전 차이가 심해집니다.  
[K8s version skew policy](https://kubernetes.io/releases/version-skew-policy/)를 넘어 어긋나기 전에 수동으로 업데이트해야 합니다.